### PR TITLE
Init commit new simplified api

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -12,9 +12,9 @@ public class app/cash/kfsm/State {
 
 public class app/cash/kfsm/Transition {
 	public fun <init> (Lapp/cash/kfsm/State;Lapp/cash/kfsm/State;)V
-	public fun <init> (Ljava/util/Set;Lapp/cash/kfsm/State;)V
+	public synthetic fun <init> (Ljava/util/Set;Lapp/cash/kfsm/State;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun effect (Lapp/cash/kfsm/Value;)Larrow/core/Either;
-	public final fun getFrom ()Ljava/util/Set;
+	public final fun getFrom-5sCjGKo ()Ljava/util/Set;
 	public final fun getTo ()Lapp/cash/kfsm/State;
 }
 

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -1,3 +1,37 @@
+public final class app/cash/kfsm/InvalidStateTransition : java/lang/Exception {
+	public fun <init> (Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;)V
+}
+
+public class app/cash/kfsm/State {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun canReach (Lapp/cash/kfsm/State;)Z
+	public fun canTransitionTo (Lapp/cash/kfsm/State;)Z
+	public final fun getReachable ()Ljava/util/Set;
+	public final fun getTransitions ()Ljava/util/Set;
+}
+
+public class app/cash/kfsm/Transition {
+	public fun <init> (Lapp/cash/kfsm/State;Lapp/cash/kfsm/State;)V
+	public fun <init> (Ljava/util/Set;Lapp/cash/kfsm/State;)V
+	public fun effect (Lapp/cash/kfsm/Value;)Larrow/core/Either;
+	public final fun getFrom ()Ljava/util/Set;
+	public final fun getTo ()Lapp/cash/kfsm/State;
+}
+
+public class app/cash/kfsm/Transitioner {
+	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun postHook (Lapp/cash/kfsm/Value;)Larrow/core/Either;
+	public fun preHook (Lapp/cash/kfsm/Value;)Larrow/core/Either;
+	public final fun transition (Lapp/cash/kfsm/Value;Lapp/cash/kfsm/Transition;)Larrow/core/Either;
+}
+
+public abstract interface class app/cash/kfsm/Value {
+	public abstract fun getState ()Lapp/cash/kfsm/State;
+	public abstract fun update (Lapp/cash/kfsm/State;)Lapp/cash/kfsm/Value;
+}
+
 public final class com/squareup/cash/kfsm/DefaultStateTransitioner : com/squareup/cash/kfsm/StateTransitioner {
 	public fun <init> (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -4,10 +4,10 @@ public final class app/cash/kfsm/InvalidStateTransition : java/lang/Exception {
 
 public class app/cash/kfsm/State {
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V
-	public fun canReach (Lapp/cash/kfsm/State;)Z
-	public fun canTransitionTo (Lapp/cash/kfsm/State;)Z
-	public final fun getReachable ()Ljava/util/Set;
-	public final fun getTransitions ()Ljava/util/Set;
+	public fun canDirectlyTransitionTo (Lapp/cash/kfsm/State;)Z
+	public fun canEventuallyTransitionTo (Lapp/cash/kfsm/State;)Z
+	public final fun getReachableStates ()Ljava/util/Set;
+	public final fun getSubsequentStates ()Ljava/util/Set;
 }
 
 public class app/cash/kfsm/Transition {

--- a/lib/src/main/kotlin/app/cash/kfsm/InvalidStateTransition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/InvalidStateTransition.kt
@@ -1,5 +1,7 @@
 package app.cash.kfsm
 
 class InvalidStateTransition(transition: Transition<*>, value: Value<*>) : Exception(
-  "Value cannot transition ${transition.from} to ${transition.to}, because it is currently ${value.state}"
+  "Value cannot transition ${
+    transition.from.toList().sortedBy { it.toString() }.joinToString(", ", prefix = "{", postfix = "}")
+  } to ${transition.to}, because it is currently ${value.state}"
 )

--- a/lib/src/main/kotlin/app/cash/kfsm/InvalidStateTransition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/InvalidStateTransition.kt
@@ -1,0 +1,5 @@
+package app.cash.kfsm
+
+class InvalidStateTransition(transition: Transition<*>, value: Value<*>) : Exception(
+  "Value cannot transition ${transition.from} to ${transition.to}, because it is currently ${value.state}"
+)

--- a/lib/src/main/kotlin/app/cash/kfsm/State.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/State.kt
@@ -1,0 +1,25 @@
+package app.cash.kfsm
+
+open class State(transitionsFn: () -> Set<State>) {
+
+  /** all states that can be transitioned to directly from this state */
+  val transitions: Set<State> by lazy { transitionsFn() }
+
+  /** all states that are reachable from this state */
+  val reachable: Set<State> by lazy { expand() }
+
+  /**
+   * Whether this state can transition to the given other state.
+   */
+  open fun canTransitionTo(other: State): Boolean = transitions.contains(other)
+
+  /**
+   * Whether this state could directly or indirectly transition to the given state.
+   */
+  open fun canReach(other: State): Boolean = reachable.contains(other)
+
+  private fun expand(found: Set<State> = emptySet()): Set<State> =
+    transitions.minus(found).flatMap {
+      it.expand(transitions + found) + it
+    }.toSet().plus(found)
+}

--- a/lib/src/main/kotlin/app/cash/kfsm/State.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/State.kt
@@ -3,23 +3,23 @@ package app.cash.kfsm
 open class State(transitionsFn: () -> Set<State>) {
 
   /** all states that can be transitioned to directly from this state */
-  val transitions: Set<State> by lazy { transitionsFn() }
+  val subsequentStates: Set<State> by lazy { transitionsFn() }
 
   /** all states that are reachable from this state */
-  val reachable: Set<State> by lazy { expand() }
+  val reachableStates: Set<State> by lazy { expand() }
 
   /**
    * Whether this state can transition to the given other state.
    */
-  open fun canTransitionTo(other: State): Boolean = transitions.contains(other)
+  open fun canDirectlyTransitionTo(other: State): Boolean = subsequentStates.contains(other)
 
   /**
    * Whether this state could directly or indirectly transition to the given state.
    */
-  open fun canReach(other: State): Boolean = reachable.contains(other)
+  open fun canEventuallyTransitionTo(other: State): Boolean = reachableStates.contains(other)
 
   private fun expand(found: Set<State> = emptySet()): Set<State> =
-    transitions.minus(found).flatMap {
-      it.expand(transitions + found) + it
+    subsequentStates.minus(found).flatMap {
+      it.expand(subsequentStates + found) + it
     }.toSet().plus(found)
 }

--- a/lib/src/main/kotlin/app/cash/kfsm/Transition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Transition.kt
@@ -1,18 +1,19 @@
 package app.cash.kfsm
 
 import app.cash.quiver.extensions.ErrorOr
+import arrow.core.NonEmptySet
+import arrow.core.nonEmptySetOf
 import arrow.core.right
 
-open class Transition<S : State>(val from: Set<S>, val to: S) {
+open class Transition<S : State>(val from: NonEmptySet<S>, val to: S) {
 
   init {
-    require(from.isNotEmpty()) { "from must not be empty" }
     from.filterNot { it.canTransitionTo(to) }.let {
       require(it.isEmpty()) { "invalid transition(s): ${it.map { from -> "$from->$to" }}" }
     }
   }
 
-  constructor(from: S, to: S) : this(setOf(from), to)
+  constructor(from: S, to: S) : this(nonEmptySetOf(from), to)
 
   open fun effect(value: Value<S>): ErrorOr<Value<S>> = value.right()
 }

--- a/lib/src/main/kotlin/app/cash/kfsm/Transition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Transition.kt
@@ -8,7 +8,7 @@ import arrow.core.right
 open class Transition<S : State>(val from: NonEmptySet<S>, val to: S) {
 
   init {
-    from.filterNot { it.canTransitionTo(to) }.let {
+    from.filterNot { it.canDirectlyTransitionTo(to) }.let {
       require(it.isEmpty()) { "invalid transition(s): ${it.map { from -> "$from->$to" }}" }
     }
   }

--- a/lib/src/main/kotlin/app/cash/kfsm/Transition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Transition.kt
@@ -1,0 +1,18 @@
+package app.cash.kfsm
+
+import app.cash.quiver.extensions.ErrorOr
+import arrow.core.right
+
+open class Transition<S : State>(val from: Set<S>, val to: S) {
+
+  init {
+    require(from.isNotEmpty()) { "from must not be empty" }
+    from.filterNot { it.canTransitionTo(to) }.let {
+      require(it.isEmpty()) { "invalid transition(s): ${it.map { from -> "$from->$to" }}" }
+    }
+  }
+
+  constructor(from: S, to: S) : this(setOf(from), to)
+
+  open fun effect(value: Value<S>): ErrorOr<Value<S>> = value.right()
+}

--- a/lib/src/main/kotlin/app/cash/kfsm/Transitioner.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Transitioner.kt
@@ -1,0 +1,47 @@
+package app.cash.kfsm
+
+import app.cash.quiver.extensions.ErrorOr
+import app.cash.quiver.extensions.flatTap
+import arrow.core.Either
+import arrow.core.flatMap
+import arrow.core.flatten
+import arrow.core.left
+import arrow.core.raise.either
+import arrow.core.right
+
+open class Transitioner<S : State>(
+  private val persist: (Value<S>) -> ErrorOr<Value<S>> = { it.right() }
+) {
+
+  open fun preHook(value: Value<S>): ErrorOr<Unit> = Unit.right()
+
+  open fun postHook(value: Value<S>): ErrorOr<Unit> = Unit.right()
+
+  fun transition(
+    value: Value<S>,
+    transition: Transition<S>
+  ): ErrorOr<Value<S>> = when {
+    transition.from.contains(value.state) -> doTheTransition(value, transition)
+    // Self-cycled transitions will be effected by the first case.
+    // If we still see a transition to self then this is a no-op.
+    transition.to == value.state -> ignoreAlreadyCompletedTransition(value, transition)
+    else -> InvalidStateTransition(transition, value).left()
+  }
+
+  private fun doTheTransition(
+    value: Value<S>,
+    transition: Transition<S>
+  ) = Either.catch {
+    preHook(value)
+      .flatMap{ transition.effect(value) }
+      .map { it.update(transition.to) }
+      .flatMap { persist(it) }
+      .flatTap { postHook(it) }
+  }.flatten()
+
+  private fun ignoreAlreadyCompletedTransition(
+    value: Value<S>,
+    transition: Transition<S>
+  ) = value.update(transition.to).right()
+}
+

--- a/lib/src/main/kotlin/app/cash/kfsm/Value.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Value.kt
@@ -1,0 +1,6 @@
+package app.cash.kfsm
+
+interface Value<S : State> {
+  val state: S
+  fun update(newState: S): Value<S>
+}

--- a/lib/src/test/kotlin/app/cash/kfsm/InvalidStateTransitionTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/InvalidStateTransitionTest.kt
@@ -1,0 +1,17 @@
+package app.cash.kfsm
+
+import arrow.core.nonEmptySetOf
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class InvalidStateTransitionTest : StringSpec({
+  "with single from-state has correct message" {
+    InvalidStateTransition(Transition(A, B), Letter(E)).message shouldBe
+      "Value cannot transition {A} to B, because it is currently E"
+  }
+
+  "with many from-states has correct message" {
+    InvalidStateTransition(Transition(nonEmptySetOf(C, B), D), Letter(E)).message shouldBe
+      "Value cannot transition {B, C} to D, because it is currently E"
+  }
+})

--- a/lib/src/test/kotlin/app/cash/kfsm/Letter.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/Letter.kt
@@ -1,0 +1,14 @@
+package app.cash.kfsm
+
+/** A simple state machine that represents a letter of the alphabet. */
+data class Letter(override val state: LetterState) : Value<LetterState> {
+  override fun update(newState: LetterState): Letter = copy(state = newState)
+}
+
+sealed class LetterState(to: () -> Set<LetterState>) : State(to)
+
+data object A : LetterState(to = { setOf(B) })
+data object B : LetterState(to = { setOf(C, D) })
+data object C : LetterState(to = { setOf(D) })
+data object D : LetterState(to = { setOf(B, E) })
+data object E : LetterState(to = { emptySet() })

--- a/lib/src/test/kotlin/app/cash/kfsm/Letter.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/Letter.kt
@@ -8,7 +8,7 @@ data class Letter(override val state: LetterState) : Value<LetterState> {
 sealed class LetterState(to: () -> Set<LetterState>) : State(to)
 
 data object A : LetterState(to = { setOf(B) })
-data object B : LetterState(to = { setOf(C, D) })
+data object B : LetterState(to = { setOf(B, C, D) })
 data object C : LetterState(to = { setOf(D) })
 data object D : LetterState(to = { setOf(B, E) })
 data object E : LetterState(to = { emptySet() })

--- a/lib/src/test/kotlin/app/cash/kfsm/StateTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/StateTest.kt
@@ -1,0 +1,58 @@
+package app.cash.kfsm
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class StateTest : StringSpec({
+
+  "state knows which states it can directly transition to" {
+    A.subsequentStates shouldBe setOf(B)
+    B.subsequentStates shouldBe setOf(B, C, D)
+    C.subsequentStates shouldBe setOf(D)
+    D.subsequentStates shouldBe setOf(B, E)
+    E.subsequentStates shouldBe emptySet()
+  }
+
+  "state knows which states it can eventually transition to" {
+    A.reachableStates shouldBe setOf(B, C, D, E)
+    B.reachableStates shouldBe setOf(B, C, D, E)
+    C.reachableStates shouldBe setOf(B, C, D, E)
+    D.reachableStates shouldBe setOf(B, C, D, E)
+    E.reachableStates shouldBe emptySet()
+  }
+
+  "state reports that it can transition to another state" {
+    A.canDirectlyTransitionTo(B) shouldBe true
+    B.canDirectlyTransitionTo(B) shouldBe true // self
+  }
+
+  "state reports that it cannot transition to another state" {
+    A.canDirectlyTransitionTo(A) shouldBe false
+    A.canDirectlyTransitionTo(C) shouldBe false
+    A.canDirectlyTransitionTo(D) shouldBe false
+    A.canDirectlyTransitionTo(E) shouldBe false
+
+    C.canDirectlyTransitionTo(B) shouldBe false // reverse
+    C.canDirectlyTransitionTo(C) shouldBe false // self
+  }
+
+  "state reports if it can eventually transition to another state" {
+    A.canEventuallyTransitionTo(B) shouldBe true
+    A.canEventuallyTransitionTo(C) shouldBe true
+    A.canEventuallyTransitionTo(D) shouldBe true
+    A.canEventuallyTransitionTo(E) shouldBe true
+  }
+
+  "state reports if it can eventually transition to another state via a cycle" {
+    C.canEventuallyTransitionTo(B) shouldBe true
+    C.canEventuallyTransitionTo(C) shouldBe true
+  }
+
+  "state reports if it cannot eventually transition to another state" {
+    A.canEventuallyTransitionTo(A) shouldBe false
+    C.canEventuallyTransitionTo(A) shouldBe false
+    E.canEventuallyTransitionTo(C) shouldBe false
+    E.canEventuallyTransitionTo(E) shouldBe false
+  }
+
+})

--- a/lib/src/test/kotlin/app/cash/kfsm/TransitionTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/TransitionTest.kt
@@ -1,0 +1,21 @@
+package app.cash.kfsm
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class TransitionTest : StringSpec({
+
+  "cannot create an invalid state transition" {
+    shouldThrow<IllegalArgumentException> { Transition(A, C) }
+  }
+
+  "cannot create an invalid state transition from a set of states" {
+    shouldThrow<IllegalArgumentException> { Transition(setOf(B, A), C) }
+  }
+
+  "cannot create a transition from nothing" {
+    shouldThrow<IllegalArgumentException> { Transition(emptySet(), C) }
+  }
+
+})

--- a/lib/src/test/kotlin/app/cash/kfsm/TransitionTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/TransitionTest.kt
@@ -1,8 +1,8 @@
 package app.cash.kfsm
 
+import arrow.core.nonEmptySetOf
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
 
 class TransitionTest : StringSpec({
 
@@ -11,11 +11,7 @@ class TransitionTest : StringSpec({
   }
 
   "cannot create an invalid state transition from a set of states" {
-    shouldThrow<IllegalArgumentException> { Transition(setOf(B, A), C) }
-  }
-
-  "cannot create a transition from nothing" {
-    shouldThrow<IllegalArgumentException> { Transition(emptySet(), C) }
+    shouldThrow<IllegalArgumentException> { Transition(nonEmptySetOf(B, A), C) }
   }
 
 })

--- a/lib/src/test/kotlin/app/cash/kfsm/TransitionerTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/TransitionerTest.kt
@@ -59,7 +59,7 @@ class TransitionerTest : StringSpec({
     val transitioner = transitioner()
 
     transitioner.transition(Letter(C), transition).shouldBeLeft()
-      .shouldHaveMessage("Value cannot transition [A] to B, because it is currently C")
+      .shouldHaveMessage("Value cannot transition {A} to B, because it is currently C")
 
     transitioner.preHookExecuted shouldBe 0
     transition.effected shouldBe 0

--- a/lib/src/test/kotlin/app/cash/kfsm/TransitionerTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/TransitionerTest.kt
@@ -202,5 +202,24 @@ class TransitionerTest : StringSpec({
     transitioner.postHookExecuted shouldBe 7
   }
 
+  "can transition to self" {
+    val aToB = transition(A, B)
+    val bToB = transition(B, B)
+    val bToC = transition(B, C)
+    val transitioner = transitioner()
+
+    transitioner.transition(Letter(A), aToB)
+      .flatMap { transitioner.transition(it, bToB) }
+      .flatMap { transitioner.transition(it, bToB) }
+      .flatMap { transitioner.transition(it, bToB) }
+      .flatMap { transitioner.transition(it, bToC) } shouldBeRight Letter(C)
+
+    transitioner.preHookExecuted shouldBe 5
+    aToB.effected shouldBe 1
+    bToB.effected shouldBe 3
+    bToC.effected shouldBe 1
+    transitioner.postHookExecuted shouldBe 5
+  }
+
 })
 

--- a/lib/src/test/kotlin/app/cash/kfsm/TransitionerTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/TransitionerTest.kt
@@ -1,0 +1,206 @@
+package app.cash.kfsm
+
+import app.cash.quiver.extensions.ErrorOr
+import arrow.core.flatMap
+import arrow.core.left
+import arrow.core.right
+import io.kotest.assertions.arrow.core.shouldBeLeft
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+
+class TransitionerTest : StringSpec({
+
+  fun transitioner(
+    pre: (Value<LetterState>) -> ErrorOr<Unit> = { Unit.right() },
+    post: (Value<LetterState>) -> ErrorOr<Unit> = { Unit.right() },
+    persist: (Value<LetterState>) -> ErrorOr<Value<LetterState>> = { it.right() },
+  ) = object : Transitioner<LetterState>(persist) {
+    var preHookExecuted = 0
+    var postHookExecuted = 0
+
+    override fun preHook(value: Value<LetterState>): ErrorOr<Unit> = pre(value).also { preHookExecuted += 1 }
+    override fun postHook(value: Value<LetterState>): ErrorOr<Unit> = post(value).also { postHookExecuted += 1 }
+  }
+
+  fun transition(from: LetterState = A, to: LetterState = B) = object : Transition<LetterState>(from, to) {
+    var effected = 0
+    override fun effect(value: Value<LetterState>): ErrorOr<Value<LetterState>> {
+      effected += 1
+      return value.update(to).right()
+    }
+  }
+
+  "effects valid transition" {
+    val transition = transition()
+    val transitioner = transitioner()
+
+    transitioner.transition(Letter(A), transition) shouldBeRight Letter(B)
+
+    transitioner.preHookExecuted shouldBe 1
+    transition.effected shouldBe 1
+    transitioner.postHookExecuted shouldBe 1
+  }
+
+  "ignores completed transition" {
+    val transition = transition()
+    val transitioner = transitioner()
+
+    transitioner.transition(Letter(B), transition) shouldBeRight Letter(B)
+
+    transitioner.preHookExecuted shouldBe 0
+    transition.effected shouldBe 0
+    transitioner.postHookExecuted shouldBe 0
+  }
+
+  "returns error on invalid transition" {
+    val transition = transition()
+    val transitioner = transitioner()
+
+    transitioner.transition(Letter(C), transition).shouldBeLeft()
+      .shouldHaveMessage("Value cannot transition [A] to B, because it is currently C")
+
+    transitioner.preHookExecuted shouldBe 0
+    transition.effected shouldBe 0
+    transitioner.postHookExecuted shouldBe 0
+  }
+
+  "returns error when preHook errors" {
+    val error = RuntimeException("preHook error")
+
+    val transition = transition()
+    val transitioner = transitioner(pre = { error.left() })
+
+    transitioner.transition(Letter(A), transition) shouldBeLeft error
+
+    transitioner.preHookExecuted shouldBe 1
+    transition.effected shouldBe 0
+    transitioner.postHookExecuted shouldBe 0
+  }
+
+  "returns error when effect errors" {
+    val error = RuntimeException("effect error")
+
+    val transition = object : Transition<LetterState>(A, B) {
+      override fun effect(value: Value<LetterState>): ErrorOr<Value<LetterState>> = error.left()
+    }
+    val transitioner = transitioner()
+
+    transitioner.transition(Letter(A), transition) shouldBeLeft error
+
+    transitioner.preHookExecuted shouldBe 1
+    transitioner.postHookExecuted shouldBe 0
+  }
+
+  "returns error when postHook errors" {
+    val error = RuntimeException("postHook error")
+
+    val transition = transition()
+    val transitioner = transitioner(post = { error.left() })
+
+    transitioner.transition(Letter(A), transition) shouldBeLeft error
+
+    transition.effected shouldBe 1
+    transitioner.preHookExecuted shouldBe 1
+    transitioner.postHookExecuted shouldBe 1
+  }
+
+  "returns error when preHook throws" {
+    val error = RuntimeException("preHook error")
+
+    val transition = transition()
+    val transitioner = transitioner(pre = { throw error })
+
+    transitioner.transition(Letter(A), transition) shouldBeLeft error
+
+    transition.effected shouldBe 0
+    transitioner.postHookExecuted shouldBe 0
+  }
+
+  "returns error when effect throws" {
+    val error = RuntimeException("effect error")
+
+    val transition = object : Transition<LetterState>(A, B) {
+      override fun effect(value: Value<LetterState>): ErrorOr<Value<LetterState>> = throw error
+    }
+    val transitioner = transitioner()
+
+    transitioner.transition(Letter(A), transition) shouldBeLeft error
+
+    transitioner.preHookExecuted shouldBe 1
+    transitioner.postHookExecuted shouldBe 0
+  }
+
+  "returns error when postHook throws" {
+    val error = RuntimeException("postHook error")
+
+    val transition = transition()
+    val transitioner = transitioner(post = { throw error })
+
+    transitioner.transition(Letter(A), transition) shouldBeLeft error
+
+    transition.effected shouldBe 1
+    transitioner.preHookExecuted shouldBe 1
+  }
+
+  "returns error when persist fails" {
+    val error = RuntimeException("persist error")
+
+    val transition = transition()
+    val transitioner = transitioner(persist = { error.left() })
+
+    transitioner.transition(Letter(A), transition) shouldBeLeft error
+
+    transitioner.preHookExecuted shouldBe 1
+    transition.effected shouldBe 1
+    transitioner.postHookExecuted shouldBe 0
+  }
+
+  "can transition multiple times" {
+    val aToB = transition(A, B)
+    val bToC = transition(B, C)
+    val cToD = transition(C, D)
+    val dToE = transition(D, E)
+    val transitioner = transitioner()
+
+    transitioner.transition(Letter(A), aToB)
+      .flatMap { transitioner.transition(it, bToC) }
+      .flatMap { transitioner.transition(it, cToD) }
+      .flatMap { transitioner.transition(it, dToE) } shouldBeRight Letter(E)
+
+    transitioner.preHookExecuted shouldBe 4
+    aToB.effected shouldBe 1
+    bToC.effected shouldBe 1
+    cToD.effected shouldBe 1
+    dToE.effected shouldBe 1
+    transitioner.postHookExecuted shouldBe 4
+  }
+
+  "can transition in a loop" {
+    val aToB = transition(A, B)
+    val bToC = transition(B, C)
+    val cToD = transition(C, D)
+    val dToB = transition(D, B)
+    val dToE = transition(D, E)
+    val transitioner = transitioner()
+
+    transitioner.transition(Letter(A), aToB)
+      .flatMap { transitioner.transition(it, bToC) }
+      .flatMap { transitioner.transition(it, cToD) }
+      .flatMap { transitioner.transition(it, dToB) }
+      .flatMap { transitioner.transition(it, bToC) }
+      .flatMap { transitioner.transition(it, cToD) }
+      .flatMap { transitioner.transition(it, dToE) } shouldBeRight Letter(E)
+
+    transitioner.preHookExecuted shouldBe 7
+    aToB.effected shouldBe 1
+    bToC.effected shouldBe 2
+    cToD.effected shouldBe 2
+    dToB.effected shouldBe 1
+    dToE.effected shouldBe 1
+    transitioner.postHookExecuted shouldBe 7
+  }
+
+})
+

--- a/lib/src/test/kotlin/app/cash/kfsm/TransitionerTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/TransitionerTest.kt
@@ -157,6 +157,19 @@ class TransitionerTest : StringSpec({
     transitioner.postHookExecuted shouldBe 0
   }
 
+  "returns error when persist throws" {
+    val error = RuntimeException("persist error")
+
+    val transition = transition()
+    val transitioner = transitioner(persist = { throw error })
+
+    transitioner.transition(Letter(A), transition) shouldBeLeft error
+
+    transitioner.preHookExecuted shouldBe 1
+    transition.effected shouldBe 1
+    transitioner.postHookExecuted shouldBe 0
+  }
+
   "can transition multiple times" {
     val aToB = transition(A, B)
     val bToC = transition(B, C)


### PR DESCRIPTION
The original API did too much.
In this PR we introduce a new, simplified API. 

1. Each transition will provide an optional effect. 
2. The transitioner will define how to persist updated values, and any pre and post hooks.
3. The values know their state and how to update the state.

Gone are the notions of notifications, notification types, error types etc.

The new api is in the `app.cash.kfsm` package. See `TransitionerTest` for usage. 
