### PR TITLE
Type alias the value so implementors can work on the real things

### DIFF
--- a/lib/src/main/kotlin/app/cash/kfsm/InvalidStateTransition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/InvalidStateTransition.kt
@@ -1,6 +1,6 @@
 package app.cash.kfsm
 
-class InvalidStateTransition(transition: Transition<*>, value: Value<*>) : Exception(
+class InvalidStateTransition(transition: Transition<*, *>, value: Value<*, *>) : Exception(
   "Value cannot transition ${
     transition.from.toList().sortedBy { it.toString() }.joinToString(", ", prefix = "{", postfix = "}")
   } to ${transition.to}, because it is currently ${value.state}"

--- a/lib/src/main/kotlin/app/cash/kfsm/Transition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Transition.kt
@@ -5,7 +5,7 @@ import arrow.core.NonEmptySet
 import arrow.core.nonEmptySetOf
 import arrow.core.right
 
-open class Transition<S : State>(val from: NonEmptySet<S>, val to: S) {
+open class Transition<V: Value<V, S>, S : State>(val from: NonEmptySet<S>, val to: S) {
 
   init {
     from.filterNot { it.canDirectlyTransitionTo(to) }.let {
@@ -15,5 +15,5 @@ open class Transition<S : State>(val from: NonEmptySet<S>, val to: S) {
 
   constructor(from: S, to: S) : this(nonEmptySetOf(from), to)
 
-  open fun effect(value: Value<S>): ErrorOr<Value<S>> = value.right()
+  open fun effect(value: V): ErrorOr<V> = value.right()
 }

--- a/lib/src/main/kotlin/app/cash/kfsm/Value.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Value.kt
@@ -1,6 +1,6 @@
 package app.cash.kfsm
 
-interface Value<S : State> {
+interface Value<V: Value<V, S>, S : State> {
   val state: S
-  fun update(newState: S): Value<S>
+  fun update(newState: S): V
 }

--- a/lib/src/test/kotlin/app/cash/kfsm/InvalidStateTransitionTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/InvalidStateTransitionTest.kt
@@ -6,12 +6,12 @@ import io.kotest.matchers.shouldBe
 
 class InvalidStateTransitionTest : StringSpec({
   "with single from-state has correct message" {
-    InvalidStateTransition(Transition(A, B), Letter(E)).message shouldBe
+    InvalidStateTransition(LetterTransition(A, B), Letter(E)).message shouldBe
       "Value cannot transition {A} to B, because it is currently E"
   }
 
   "with many from-states has correct message" {
-    InvalidStateTransition(Transition(nonEmptySetOf(C, B), D), Letter(E)).message shouldBe
+    InvalidStateTransition(LetterTransition(nonEmptySetOf(C, B), D), Letter(E)).message shouldBe
       "Value cannot transition {B, C} to D, because it is currently E"
   }
 })

--- a/lib/src/test/kotlin/app/cash/kfsm/Letter.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/Letter.kt
@@ -1,14 +1,14 @@
 package app.cash.kfsm
 
 /** A simple state machine that represents a letter of the alphabet. */
-data class Letter(override val state: LetterState) : Value<LetterState> {
-  override fun update(newState: LetterState): Letter = copy(state = newState)
+data class Letter(override val state: Char) : Value<Letter, Char> {
+  override fun update(newState: Char): Letter = copy(state = newState)
 }
 
-sealed class LetterState(to: () -> Set<LetterState>) : State(to)
+sealed class Char(to: () -> Set<Char>) : State(to)
 
-data object A : LetterState(to = { setOf(B) })
-data object B : LetterState(to = { setOf(B, C, D) })
-data object C : LetterState(to = { setOf(D) })
-data object D : LetterState(to = { setOf(B, E) })
-data object E : LetterState(to = { emptySet() })
+data object A : Char(to = { setOf(B) })
+data object B : Char(to = { setOf(B, C, D) })
+data object C : Char(to = { setOf(D) })
+data object D : Char(to = { setOf(B, E) })
+data object E : Char(to = { emptySet() })

--- a/lib/src/test/kotlin/app/cash/kfsm/TransitionTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/TransitionTest.kt
@@ -4,14 +4,16 @@ import arrow.core.nonEmptySetOf
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 
+typealias LetterTransition = Transition<Letter, Char>
+
 class TransitionTest : StringSpec({
 
   "cannot create an invalid state transition" {
-    shouldThrow<IllegalArgumentException> { Transition(A, C) }
+    shouldThrow<IllegalArgumentException> { LetterTransition(A, C) }
   }
 
   "cannot create an invalid state transition from a set of states" {
-    shouldThrow<IllegalArgumentException> { Transition(nonEmptySetOf(B, A), C) }
+    shouldThrow<IllegalArgumentException> { LetterTransition(nonEmptySetOf(B, A), C) }
   }
 
 })


### PR DESCRIPTION
 not abstractions,

The prior version of the API required the implementor to implement things like `persist: (Value<S>) -> ErrorOr<Value<S>>`. This doesn't allow for meaningful implementations. This PR changes it so that the implementor can:

```kotlin
data class Foo(override val state: Bar) : Value<Foo, Bar> {
  override fun update(newState: Bar) = copy(state = newState)
}

val persist: (Foo) -> ErrorOr<Foo>
```

instead of being constrained to 

```kotlin
val persist: (Value<Bar>) -> ErrorOr<Value<Bar>>
```
