### PR TITLE
Define a type argument for transitions so that they can have sub-heirarchy classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Breaking
+
+* Refined type aliases on Transitioner so that implementations are free to define a base transition type that may
+  implement common functionality. For example, a new base transition type can define a common way to execute
+  side-effects that occur in pre and post hook transitioner functions. See TransitionerTest use of 
+  `specificToThisTransitionType` for an example.
+
 ## [0.1.0]
 
 ### Breaking

--- a/lib/src/test/kotlin/app/cash/kfsm/TransitionTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/TransitionTest.kt
@@ -1,10 +1,9 @@
 package app.cash.kfsm
 
+import arrow.core.NonEmptySet
 import arrow.core.nonEmptySetOf
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
-
-typealias LetterTransition = Transition<Letter, Char>
 
 class TransitionTest : StringSpec({
 
@@ -17,3 +16,10 @@ class TransitionTest : StringSpec({
   }
 
 })
+
+open class LetterTransition(from: NonEmptySet<Char>, to: Char): Transition<Letter, Char>(from, to) {
+  constructor(from: Char, to: Char) : this(nonEmptySetOf(from), to)
+
+  val specificToThisTransitionType: String = "$from -> $to"
+}
+

--- a/lib/src/test/kotlin/app/cash/kfsm/TransitionerTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/TransitionerTest.kt
@@ -16,7 +16,7 @@ class TransitionerTest : StringSpec({
     pre: (Letter, LetterTransition) -> ErrorOr<Unit> = { _, _ -> Unit.right() },
     post: (Char, Letter, LetterTransition) -> ErrorOr<Unit> = { _, _, _ -> Unit.right() },
     persist: (Letter) -> ErrorOr<Letter> = { it.right() },
-  ) = object : Transitioner<Letter, Char>(persist) {
+  ) = object : Transitioner<LetterTransition, Letter, Char>(persist) {
     var preHookExecuted = 0
     var postHookExecuted = 0
 
@@ -243,6 +243,7 @@ class TransitionerTest : StringSpec({
       pre = { value, t ->
         value shouldBe Letter(A)
         t shouldBe transition
+        t.specificToThisTransitionType shouldBe "NonEmptySet(A) -> B"
         Unit.right()
       }
     )
@@ -251,17 +252,18 @@ class TransitionerTest : StringSpec({
   }
 
   "post hook contains the correct from state, post value and transition" {
-    val transition = transition()
+    val transition = transition(from = B, to = C)
     val transitioner = transitioner(
       post = { from, value, t->
-        from shouldBe A
-        value shouldBe Letter(B)
+        from shouldBe B
+        value shouldBe Letter(C)
         t shouldBe transition
+        t.specificToThisTransitionType shouldBe "NonEmptySet(B) -> C"
         Unit.right()
       }
     )
 
-    transitioner.transition(Letter(A), transition).shouldBeRight()
+    transitioner.transition(Letter(B), transition).shouldBeRight()
   }
 })
 


### PR DESCRIPTION
An early user of the new API discovered that the only way to effectively encode pre and post hook transitioner logic is to map on the transition type (or the to/from states). It would be better if the transition itself could define common values and functions. However, this was not possible as the Transitioner only defined type aliases for the value and state. In this change we introduce a type alias for the transition too, so that it can be extended. See changes to TransitionerTest and TransitionTest's LetterTransition for an example.
