### PR TITLE
Update Dokka to 2.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,39 +19,44 @@ subprojects {
       jvmTarget = "11"
     }
   }
-  
+
   tasks.withType<Test> {
     useJUnitPlatform()
   }
 
-  // Configure Dokka for each subproject
-  tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
-    dokkaSourceSets {
-      named("main") {
-        includes.from("module.md")
-        moduleName.set(project.name)
-        sourceLink {
-          localDirectory.set(file("src/main/kotlin"))
-          remoteUrl.set(uri("https://github.com/block/kfsm/tree/main/${project.name}/src/main/kotlin").toURL())
-          remoteLineSuffix.set("#L")
-        }
+  dokka {
+    moduleName.set(project.name)
+    dokkaPublications.html {
+      suppressInheritedMembers.set(true)
+      failOnWarning.set(true)
+    }
+    dokkaSourceSets.configureEach {
+      includes.from("module.md")
+      sourceLink {
+        localDirectory.set(file("src/main/kotlin"))
+        remoteUrl.set(uri("https://github.com/block/kfsm/tree/main/${project.name}/src/main/kotlin"))
+        remoteLineSuffix.set("#L")
       }
     }
   }
 }
 
 // Configure Dokka multi-module task
-tasks.dokkaHtmlMultiModule {
-  outputDirectory.set(layout.buildDirectory.dir("dokka/html"))
-  includes.from("dokka-docs/module.md")
+dokka {
   moduleName.set("kfsm")
   moduleVersion.set(project.version.toString())
+  dokkaPublications {
+    register("multiModule") {
+      outputDirectory.set(layout.buildDirectory.dir("dokka/html"))
+      includes.from("dokka-docs/module.md")
+    }
+  }
 }
 
 task("publishToMavenCentral") {
   group = "publishing"
   dependsOn(
     ":lib:publishToMavenCentral",
-    ":lib-guice:publishToMavenCentral",
+    ":lib-guice:publishToMavenCentral"
   )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@ RELEASE_SIGNING_ENABLED=true
 mavenCentralPublishing=true
 mavenCentralAutomaticPublishing=true
 signAllPublications=true
+
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ kotest = [
 ]
 
 [plugins]
-dokka = "org.jetbrains.dokka:1.9.10"
+dokka = "org.jetbrains.dokka:2.0.0"
 kotlinBinaryCompatibilityPlugin = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinBinaryCompatibilityPlugin" }
 kotlinGradlePlugin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 mavenPublish = { id = "com.vanniktech.maven.publish.base", version.ref = "mavenPublish" }


### PR DESCRIPTION
* Update Dokka plugin to 2.0.0
* Migrate build configuration to use new Dokka 2.0.0 APIs
* Enable experimental V2 mode in gradle.properties
* Configure HTML publication settings for better docs