### PR TITLE
StateMachine.advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+* Added `StateMachine::advance` method to automatically progress to the next state using a state selector, 
+  enabling dynamic state transitions without explicitly specifying the target state.
+
 ## [0.11.0]
 
 ### Added


### PR DESCRIPTION
# StateMachine.advance

This PR adds a new  method to the StateMachine class that automatically progresses a value to its next state using configured NextStateSelectors.

## Changes

- Added  method that:
  - Uses NextStateSelector to determine the next appropriate state
  - Performs the transition to that state
  - Returns Result<V> with either the new value or a failure
- Made  property private and immutable (Map instead of MutableMap)
- Added comprehensive tests demonstrating the advance functionality with:
  - Basic state progression
  - Error cases for missing selectors
  - Error cases for ambiguous next states

## Error Handling

The method will fail with IllegalStateException if:
- No selector is defined for the current state
- The selector fails to determine a valid next state
- The transition to the selected state is invalid

## Usage Example


```kotlin
val machine = fsm<String, Letter, Char> {
  A.becomes {
    B.via { it.copy(id = "bedford") }
  }
  B.becomes({ Result.success(C) }) {  // Selector defined for B
    C.via { it.copy(id = "citroën") }
  }
  // ...
}

val result = machine.advance(letterInStateA)  // Automatically moves to B
```