### PR TITLE
Fix version and plugin dependencies in preparation for release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -164,7 +164,7 @@ Each release includes:
   - Javadoc JAR
   - POM file
 
-- **Guice Integration**: `app.cash.kfsm:kfsm-guice:$version`
+- **Jooq Transactional Outbox Implementation**: `app.cash.kfsm:kfsm-jooq:$version`
   - Main JAR with compiled classes
   - Sources JAR
   - Javadoc JAR

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,6 @@ task("publishToMavenCentral") {
   group = "publishing"
   dependsOn(
     ":lib:publishToMavenCentral",
-    ":lib-guice:publishToMavenCentral"
+    ":lib-jooq:publishToMavenCentral"
   )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.kfsm
-VERSION_NAME=0.12.0
+VERSION_NAME=2.0.0
 
 POM_URL=https://github.com/block/kfsm/
 POM_SCM_URL=https://github.com/block/kfsm/


### PR DESCRIPTION
### TL;DR

Updated artifact information and version for the 2.0.0 release.

### What changed?

- Changed the artifact name from `kfsm-guice` to `kfsm-jooq` in the RELEASING.md documentation
- Updated the build.gradle.kts to reference the new `lib-jooq` module instead of `lib-guice`
- Bumped the version from 0.12.0 to 2.0.0 in gradle.properties