### PR TITLE
[SQBTC-1603] Add Jooq implementation for PendingRequestStore

### DIFF
--- a/example/src/main/kotlin/app/cash/kfsm/v2/exemplar/document/infra/DocumentPendingRequestSerializer.kt
+++ b/example/src/main/kotlin/app/cash/kfsm/v2/exemplar/document/infra/DocumentPendingRequestSerializer.kt
@@ -1,0 +1,77 @@
+package app.cash.kfsm.v2.exemplar.document.infra
+
+import app.cash.kfsm.v2.exemplar.document.DocumentUpload
+import app.cash.kfsm.v2.jooq.PendingRequestSerializer
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.time.Instant
+
+/**
+ * Pending request serializer for DocumentUpload using Moshi.
+ */
+object DocumentPendingRequestSerializer {
+
+  private object InstantAdapter {
+    @ToJson fun toJson(instant: Instant): String = instant.toString()
+    @FromJson fun fromJson(value: String): Instant = Instant.parse(value)
+  }
+
+  private val moshi: Moshi = Moshi.Builder()
+    .add(InstantAdapter)
+    .addLast(KotlinJsonAdapterFactory())
+    .build()
+
+  /**
+   * Intermediate representation for serializing DocumentUpload.
+   */
+  @JsonClass(generateAdapter = false)
+  private data class SerializedDocumentUpload(
+    val id: String,
+    val stateName: String,
+    val stateData: String?,
+    val fileName: String,
+    val fileSize: Long,
+    val uploadedAt: String,
+    val fileStorageId: String?,
+    val scanReport: String?
+  )
+
+  private val adapter = moshi.adapter(SerializedDocumentUpload::class.java)
+
+  val instance: PendingRequestSerializer<String, DocumentUpload> = object : PendingRequestSerializer<String, DocumentUpload> {
+    override fun serializeId(id: String): String = id
+    override fun deserializeId(serialized: String): String = serialized
+
+    override fun serializeValue(value: DocumentUpload): String {
+      val (stateName, stateData) = JsonSerializer.serializeState(value.state)
+      return adapter.toJson(
+        SerializedDocumentUpload(
+          id = value.id,
+          stateName = stateName,
+          stateData = stateData,
+          fileName = value.fileName,
+          fileSize = value.fileSize,
+          uploadedAt = value.uploadedAt.toString(),
+          fileStorageId = value.fileStorageId,
+          scanReport = JsonSerializer.serializeScanReport(value.scanReport)
+        )
+      )
+    }
+
+    override fun deserializeValue(serialized: String): DocumentUpload {
+      val dto = adapter.fromJson(serialized)!!
+      return DocumentUpload(
+        id = dto.id,
+        state = JsonSerializer.deserializeState(dto.stateName, dto.stateData),
+        fileName = dto.fileName,
+        fileSize = dto.fileSize,
+        uploadedAt = Instant.parse(dto.uploadedAt),
+        fileStorageId = dto.fileStorageId,
+        scanReport = dto.scanReport?.let { JsonSerializer.deserializeScanReport(it) }
+      )
+    }
+  }
+}

--- a/example/src/main/resources/schema.sql
+++ b/example/src/main/resources/schema.sql
@@ -31,3 +31,16 @@ CREATE TABLE IF NOT EXISTS outbox_messages (
     INDEX idx_outbox_dedup (dedup_key),
     INDEX idx_outbox_depends (depends_on_effect_id)
 );
+
+-- Pending requests table for awaitable state machine (matches lib-jooq schema)
+CREATE TABLE IF NOT EXISTS pending_requests (
+    id VARCHAR(36) PRIMARY KEY,
+    value_id VARCHAR(255) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'WAITING',
+    result_payload TEXT,
+    created_at TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at TIMESTAMP(6),
+
+    INDEX idx_pending_requests_value_status (value_id, status),
+    INDEX idx_pending_requests_status_created (status, created_at)
+);

--- a/example/src/test/kotlin/app/cash/kfsm/v2/exemplar/document/InMemoryPendingRequestStore.kt
+++ b/example/src/test/kotlin/app/cash/kfsm/v2/exemplar/document/InMemoryPendingRequestStore.kt
@@ -48,7 +48,7 @@ class InMemoryPendingRequestStore<ID, V> : PendingRequestStore<ID, V> {
     }
   }
 
-  override fun markTimedOut(requestId: String) {
+  override fun timeout(requestId: String) {
     requests[requestId]?.let { entry ->
       if (entry.status is PendingRequestStatus.Waiting) {
         entry.status = PendingRequestStatus.Failed("Timed out")

--- a/lib-jooq/src/main/kotlin/app/cash/kfsm/v2/jooq/JooqPendingRequestStore.kt
+++ b/lib-jooq/src/main/kotlin/app/cash/kfsm/v2/jooq/JooqPendingRequestStore.kt
@@ -1,0 +1,126 @@
+package app.cash.kfsm.v2.jooq
+
+import app.cash.kfsm.v2.PendingRequestStatus
+import app.cash.kfsm.v2.PendingRequestStore
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * A jOOQ-based [PendingRequestStore] implementation.
+ *
+ * Stores pending requests in a database table so that any instance can mark
+ * a request complete and any instance can poll for results.
+ *
+ * @param ID The type of unique identifier for values
+ * @param V The value type
+ * @param dsl The jOOQ DSLContext
+ * @param serializer Serializes/deserializes value IDs and values
+ * @param tableName The pending requests table name (default: "pending_requests")
+ */
+class JooqPendingRequestStore<ID, V>(
+  private val dsl: DSLContext,
+  private val serializer: PendingRequestSerializer<ID, V>,
+  private val tableName: String = "pending_requests"
+) : PendingRequestStore<ID, V> {
+
+  private val table = DSL.table(DSL.name(tableName))
+  private val idField = DSL.field(DSL.name("id"), String::class.java)
+  private val valueIdField = DSL.field(DSL.name("value_id"), String::class.java)
+  private val statusField = DSL.field(DSL.name("status"), String::class.java)
+  private val resultPayloadField = DSL.field(DSL.name("result_payload"), String::class.java)
+  private val createdAtField = DSL.field(DSL.name("created_at"), Any::class.java)
+  private val updatedAtField = DSL.field(DSL.name("updated_at"), Any::class.java)
+
+  companion object {
+    private const val STATUS_WAITING = "WAITING"
+    private const val STATUS_COMPLETED = "COMPLETED"
+    private const val STATUS_FAILED = "FAILED"
+  }
+
+  override fun create(valueId: ID): String {
+    val requestId = UUID.randomUUID().toString()
+    dsl.insertInto(
+      table,
+      idField, valueIdField, statusField, createdAtField
+    ).values(
+      requestId,
+      serializer.serializeId(valueId),
+      STATUS_WAITING,
+      Instant.now()
+    ).execute()
+    return requestId
+  }
+
+  override fun getStatus(requestId: String): PendingRequestStatus<V> {
+    val record = dsl.select(statusField, resultPayloadField)
+      .from(table)
+      .where(idField.eq(requestId))
+      .fetchOne()
+      ?: return PendingRequestStatus.NotFound
+
+    return when (record.get(statusField)) {
+      STATUS_WAITING -> PendingRequestStatus.Waiting
+      STATUS_COMPLETED -> {
+        val payload = record.get(resultPayloadField)!!
+        PendingRequestStatus.Completed(serializer.deserializeValue(payload))
+      }
+      STATUS_FAILED -> {
+        val error = record.get(resultPayloadField) ?: "Unknown error"
+        PendingRequestStatus.Failed(error)
+      }
+      else -> PendingRequestStatus.NotFound
+    }
+  }
+
+  override fun complete(valueId: ID, value: V) {
+    dsl.update(table)
+      .set(statusField, STATUS_COMPLETED)
+      .set(resultPayloadField, serializer.serializeValue(value))
+      .set(updatedAtField, Instant.now())
+      .where(valueIdField.eq(serializer.serializeId(valueId)))
+      .and(statusField.eq(STATUS_WAITING))
+      .execute()
+  }
+
+  override fun fail(valueId: ID, error: String) {
+    dsl.update(table)
+      .set(statusField, STATUS_FAILED)
+      .set(resultPayloadField, error)
+      .set(updatedAtField, Instant.now())
+      .where(valueIdField.eq(serializer.serializeId(valueId)))
+      .and(statusField.eq(STATUS_WAITING))
+      .execute()
+  }
+
+  override fun timeout(requestId: String) {
+    dsl.update(table)
+      .set(statusField, STATUS_FAILED)
+      .set(resultPayloadField, "Timed out")
+      .set(updatedAtField, Instant.now())
+      .where(idField.eq(requestId))
+      .and(statusField.eq(STATUS_WAITING))
+      .execute()
+  }
+
+  override fun delete(requestId: String) {
+    dsl.deleteFrom(table)
+      .where(idField.eq(requestId))
+      .execute()
+  }
+
+  /**
+   * Delete pending requests older than the given instant.
+   *
+   * Useful for cleaning up stale requests that were never completed or deleted.
+   *
+   * @param olderThan Delete requests created before this time
+   * @return Number of requests deleted
+   */
+  fun deleteOlderThan(olderThan: Instant): Int {
+    return dsl.deleteFrom(table)
+      .where(createdAtField.lt(olderThan))
+      .execute()
+  }
+}

--- a/lib-jooq/src/main/kotlin/app/cash/kfsm/v2/jooq/PendingRequestSchema.kt
+++ b/lib-jooq/src/main/kotlin/app/cash/kfsm/v2/jooq/PendingRequestSchema.kt
@@ -1,0 +1,49 @@
+package app.cash.kfsm.v2.jooq
+
+/**
+ * SQL schema for the pending_requests table.
+ *
+ * This object provides DDL statements for creating the pending_requests table
+ * in MySQL and PostgreSQL.
+ */
+object PendingRequestSchema {
+
+  /**
+   * MySQL DDL for creating the pending_requests table.
+   *
+   * @param tableName The table name (default: "pending_requests")
+   */
+  fun mysql(tableName: String = "pending_requests"): String = """
+    CREATE TABLE IF NOT EXISTS `$tableName` (
+      `id` VARCHAR(36) NOT NULL,
+      `value_id` VARCHAR(255) NOT NULL,
+      `status` VARCHAR(20) NOT NULL DEFAULT 'WAITING',
+      `result_payload` TEXT NULL,
+      `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+      `updated_at` TIMESTAMP(6) NULL,
+      PRIMARY KEY (`id`),
+      INDEX `idx_${tableName}_value_status` (`value_id`, `status`),
+      INDEX `idx_${tableName}_status_created` (`status`, `created_at`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  """.trimIndent()
+
+  /**
+   * PostgreSQL DDL for creating the pending_requests table.
+   *
+   * @param tableName The table name (default: "pending_requests")
+   */
+  fun postgresql(tableName: String = "pending_requests"): String = """
+    CREATE TABLE IF NOT EXISTS "$tableName" (
+      id VARCHAR(36) NOT NULL,
+      value_id VARCHAR(255) NOT NULL,
+      status VARCHAR(20) NOT NULL DEFAULT 'WAITING',
+      result_payload TEXT,
+      created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMP WITH TIME ZONE,
+      PRIMARY KEY (id)
+    );
+    
+    CREATE INDEX IF NOT EXISTS idx_${tableName}_value_status ON "$tableName" (value_id, status);
+    CREATE INDEX IF NOT EXISTS idx_${tableName}_status_created ON "$tableName" (status, created_at);
+  """.trimIndent()
+}

--- a/lib-jooq/src/main/kotlin/app/cash/kfsm/v2/jooq/PendingRequestSerializer.kt
+++ b/lib-jooq/src/main/kotlin/app/cash/kfsm/v2/jooq/PendingRequestSerializer.kt
@@ -1,0 +1,33 @@
+package app.cash.kfsm.v2.jooq
+
+/**
+ * Serializes and deserializes value IDs and values for pending request storage.
+ *
+ * Implementations should handle conversion between domain types and
+ * their string representations for database storage.
+ *
+ * @param ID The type of unique identifier for values
+ * @param V The value type
+ */
+interface PendingRequestSerializer<ID, V> {
+
+  /**
+   * Serialize a value ID to a string.
+   */
+  fun serializeId(id: ID): String
+
+  /**
+   * Deserialize a value ID from its string representation.
+   */
+  fun deserializeId(serialized: String): ID
+
+  /**
+   * Serialize a value to a string (typically JSON).
+   */
+  fun serializeValue(value: V): String
+
+  /**
+   * Deserialize a value from its string representation.
+   */
+  fun deserializeValue(serialized: String): V
+}

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -289,7 +289,7 @@ public abstract interface class app/cash/kfsm/v2/PendingRequestStore {
 	public abstract fun delete (Ljava/lang/String;)V
 	public abstract fun fail (Ljava/lang/Object;Ljava/lang/String;)V
 	public abstract fun getStatus (Ljava/lang/String;)Lapp/cash/kfsm/v2/PendingRequestStatus;
-	public abstract fun markTimedOut (Ljava/lang/String;)V
+	public abstract fun timeout (Ljava/lang/String;)V
 }
 
 public abstract class app/cash/kfsm/v2/ProcessingResult {

--- a/lib/src/main/kotlin/app/cash/kfsm/v2/AwaitableStateMachine.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/v2/AwaitableStateMachine.kt
@@ -111,7 +111,7 @@ class AwaitableStateMachine<ID, V : Value<ID, V, S>, S : State<S>, Ef : Effect>(
       val finalValue = pollForCompletion(requestId, deadline, timeout)
       Result.success(finalValue)
     } catch (e: WorkflowTimeoutException) {
-      pendingRequestStore.markTimedOut(requestId)
+      pendingRequestStore.timeout(requestId)
       Result.failure(e)
     } catch (e: WorkflowFailedException) {
       Result.failure(e)
@@ -223,7 +223,7 @@ interface PendingRequestStore<ID, V> {
    *
    * @param requestId The request ID
    */
-  fun markTimedOut(requestId: String)
+  fun timeout(requestId: String)
 
   /**
    * Delete a pending request (cleanup).

--- a/lib/src/test/kotlin/app/cash/kfsm/v2/testing/InMemoryPendingRequestStore.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/v2/testing/InMemoryPendingRequestStore.kt
@@ -64,7 +64,7 @@ class InMemoryPendingRequestStore<ID, V> : PendingRequestStore<ID, V> {
             .forEach { it.value.status = PendingRequestStatus.Failed(error) }
     }
 
-    override fun markTimedOut(requestId: String) {
+    override fun timeout(requestId: String) {
         requests.remove(requestId)
     }
 


### PR DESCRIPTION
### TL;DR

Added a JOOQ-based implementation of PendingRequestStore for persisting awaitable state machine requests in a database.

### What changed?

- Added `JooqPendingRequestStore` implementation that stores pending requests in a database table
- Created `PendingRequestSerializer` interface for converting domain objects to/from database storage
- Added `PendingRequestSchema` with DDL statements for MySQL and PostgreSQL
- Implemented `DocumentPendingRequestSerializer` for the document upload example
- Updated schema.sql with the pending_requests table definition
- Modified the AwaitableDocumentUploadIntegrationTest to use the JOOQ implementation instead of the in-memory store

### How to test?

1. Run the AwaitableDocumentUploadIntegrationTest to verify the JOOQ implementation works correctly
2. Verify that pending requests are properly stored in and retrieved from the database
3. Test the timeout and cleanup functionality by creating requests and checking their status after timeout

### Why make this change?

The previous implementation used an in-memory store for pending requests, which doesn't work in distributed environments where multiple service instances need to coordinate. This JOOQ implementation provides a persistent, database-backed store that allows any service instance to create requests and any instance to mark them complete, making the awaitable state machine pattern viable in distributed systems.