### PR TITLE
Add explicit terminal state classification and enhanced diagram generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,135 @@
+# kfsm
+
+Kotlin Finite State Machine library. Open source at [block/kfsm](https://github.com/block/kfsm).
+
+## Build
+
+```bash
+bin/gradle build                    # build + test
+bin/gradle :lib:test                # lib tests only
+bin/gradle :lib-jooq:test           # jooq tests only
+```
+
+## Structure
+
+```
+lib/          # Core library (State, Transition, Decision, Effects, StateMachine)
+lib-jooq/     # jOOQ persistence integration
+lib-guice/    # Guice DI integration
+example/      # Example usage
+```
+
+Source lives under `app.cash.kfsm.v2` — the `v2` package is the active API.
+
+## Kotlin Style
+
+2-space indent. 120 char lines. No wildcard imports. Expression syntax over imperative.
+
+### ✅ Do
+
+```kotlin
+// Sealed class hierarchies for states
+sealed class OrderState : State<OrderState>() {
+  data object Pending : OrderState() {
+    override fun transitions() = setOf(Confirmed, Cancelled)
+  }
+  data object Confirmed : OrderState() {
+    override fun transitions() = setOf(Shipped)
+  }
+}
+
+// data object for singleton states, data class when state carries data
+data class Rejected(val reason: String) : DocumentState() {
+  override fun transitions() = emptySet()
+}
+
+// Override canTransitionTo for data class states (can't appear in transitions())
+data object Uploading : DocumentState() {
+  override fun transitions(): Set<DocumentState> = setOf(Scanning)
+  override fun canTransitionTo(other: DocumentState) =
+    super.canTransitionTo(other) || other is Rejected
+}
+
+// Expression-body decide functions
+override fun decide(value: Order): Decision<Order, OrderState, OrderEffect> =
+  Decision.accept(
+    value = value.update(OrderState.Confirmed),
+    effects = listOf(OrderEffect.SendConfirmation(value.id))
+  )
+
+// Immutable values with update()
+data class Order(
+  override val id: String,
+  override val state: OrderState,
+  val total: BigDecimal
+) : Value<String, Order, OrderState> {
+  override fun update(newState: OrderState): Order = copy(state = newState)
+}
+```
+
+### ❌ Don't
+
+```kotlin
+// Don't mutate state directly — always use transitions via StateMachine
+order.copy(state = OrderState.Confirmed)  // wrong — bypasses validation
+
+// Don't put side effects in decide() — it must be pure
+override fun decide(value: Order): Decision<Order, OrderState, OrderEffect> {
+  database.save(value)  // wrong — use Effects for side effects
+  return Decision.accept(value.update(OrderState.Confirmed))
+}
+```
+
+## Testing
+
+Kotest StringSpec with `IsolationMode.InstancePerTest`. In-memory `Repository` implementations for unit tests.
+
+### ✅ Do
+
+```kotlin
+class OrderTest : StringSpec({
+  isolationMode = IsolationMode.InstancePerTest
+
+  val repository = object : Repository<String, Order, OrderState, OrderEffect> {
+    override fun saveWithOutbox(value: Order, outboxMessages: List<OutboxMessage<String, OrderEffect>>): Result<Order> {
+      return Result.success(value)
+    }
+  }
+  val stateMachine = StateMachine(repository)
+
+  "confirms a pending order" {
+    val order = Order(id = "order-1", state = OrderState.Pending, total = 100.toBigDecimal())
+    val result = stateMachine.transition(order, ConfirmOrder("pay-123"))
+
+    result.shouldBeSuccess()
+    result.getOrThrow().state shouldBe OrderState.Confirmed
+  }
+
+  "rejects transition from wrong state" {
+    val order = Order(id = "order-1", state = OrderState.Pending, total = 100.toBigDecimal())
+    val result = stateMachine.transition(order, ShipOrder("tracking-1"))
+
+    result.shouldBeFailure()
+  }
+})
+```
+
+### ❌ Don't
+
+```kotlin
+// No mocking — use in-memory Repository implementations
+val mockRepo = mockk<Repository<...>>()
+
+// No JUnit assertions
+assertEquals(OrderState.Confirmed, result.state)
+assertTrue(result.isSuccess)
+```
+
+## Key Concepts
+
+- **State** — sealed class extending `State<S>`, defines `transitions()` graph
+- **Value** — domain object implementing `Value<ID, V, S>`, carries state
+- **Transition** — declares `from`/`to` states, pure `decide()` function returns `Decision`
+- **Decision** — `Accept` (new value + effects) or `Reject` (reason string)
+- **Effects** — side effects stored in transactional outbox, `Effects.parallel()` or `Effects.ordered()`
+- **StateMachine** — orchestrates: validate transition → decide → check invariants → persist atomically

--- a/lib/src/main/kotlin/app/cash/kfsm/v2/State.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/v2/State.kt
@@ -57,6 +57,14 @@ abstract class State<S : State<S>> {
   val subsequentStates: Set<S> by lazy { transitions() }
 
   /**
+   * Whether this state is terminal (has no subsequent states).
+   *
+   * Terminal states represent the end of a state machine's lifecycle — no further transitions
+   * are possible from a terminal state.
+   */
+  val isTerminal: Boolean get() = subsequentStates.isEmpty()
+
+  /**
    * The set of all states that can eventually be reached from this state through any number of transitions.
    */
   val reachableStates: Set<S> by lazy { computeReachableStates() }

--- a/lib/src/main/kotlin/app/cash/kfsm/v2/StateMachineUtilities.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/v2/StateMachineUtilities.kt
@@ -55,15 +55,18 @@ object StateMachineUtilities {
    */
   fun <S : State<S>> mermaid(head: S): Result<String> =
     walkTree(head).map { states ->
+      val stateSet = states.toSet()
+      val transitions = stateSet.flatMap { from ->
+        from.subsequentStates.map { to -> "${from::class.simpleName} --> ${to::class.simpleName}" }
+      }.sorted()
+      val terminalTransitions = stateSet
+        .filter { it.isTerminal }
+        .map { "${it::class.simpleName} --> [*]" }
+        .sorted()
       listOf("stateDiagram-v2", "[*] --> ${head::class.simpleName}")
-        .plus(
-          states
-            .toSet()
-            .flatMap { from ->
-              from.subsequentStates.map { to -> "${from::class.simpleName} --> ${to::class.simpleName}" }
-            }.toList()
-            .sorted()
-        ).joinToString("\n")
+        .plus(transitions)
+        .plus(terminalTransitions)
+        .joinToString("\n")
     }
 
   private fun <S : State<S>> verify(

--- a/lib/src/test/kotlin/app/cash/kfsm/v2/exemplar/DocumentUploadTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/v2/exemplar/DocumentUploadTest.kt
@@ -221,6 +221,13 @@ class DocumentUploadTest : StringSpec({
     notifiedStatus shouldBe "Upload complete"
   }
 
+  "isTerminal is true for states with no subsequent states" {
+    DocumentState.Idle.isTerminal shouldBe false
+    DocumentState.Uploading.isTerminal shouldBe false
+    DocumentState.Scanning.isTerminal shouldBe false
+    DocumentState.Accepted.isTerminal shouldBe true
+  }
+
   "state machine utilities: mermaid diagram shows static transitions" {
     StateMachineUtilities.mermaid(DocumentState.Idle).shouldBeSuccess(
       """
@@ -229,6 +236,7 @@ class DocumentUploadTest : StringSpec({
       Idle --> Uploading
       Scanning --> Accepted
       Uploading --> Scanning
+      Accepted --> [*]
       """.trimIndent()
     )
   }


### PR DESCRIPTION
Add explicit terminal state classification and enhanced diagram generation

- Add isTerminal property to State (true when subsequentStates is empty)
- Render State --> [*] arrows for terminal states in StateMachineUtilities.mermaid()
- Render State --> [*] arrows for terminal states in StateMachine.mermaidStateDiagramMarkdown()
- Add tests for isTerminal and updated diagram expectations

Closes #151