### PR TITLE
Add explicit terminal state classification and enhanced diagram generation (#151)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# kfsm
+
+Kotlin Finite State Machine library. Open source at [block/kfsm](https://github.com/block/kfsm).
+
+## Build
+
+```bash
+bin/gradle build                    # build + test
+bin/gradle :lib:test                # lib tests only
+bin/gradle :lib-jooq:test           # jooq tests only
+```
+
+## Structure
+
+```
+lib/          # Core library (State, Transition, Decision, Effects, StateMachine)
+lib-jooq/     # jOOQ persistence integration
+lib-guice/    # Guice DI integration
+example/      # Example usage
+```
+
+Source lives under `app.cash.kfsm.v2` — the `v2` package is the active API.
+
+## Kotlin Style
+
+2-space indent. 120 char lines. No wildcard imports. Expression syntax over imperative.
+
+### ✅ Do
+
+```kotlin
+// Expression bodies
+fun <S : State<S>> verify(head: S): Result<Set<State<S>>> =
+  verify(head, baseType(head))
+
+// Lazy properties for computed values
+val subsequentStates: Set<S> by lazy { transitions() }
+
+// Derived boolean properties
+val isTerminal: Boolean get() = subsequentStates.isEmpty()
+
+// Functional collection transforms
+val transitions = stateSet.flatMap { from ->
+  from.subsequentStates.map { to -> "${from::class.simpleName} --> ${to::class.simpleName}" }
+}.sorted()
+
+// Sealed class hierarchies for type-safe ADTs
+sealed class Decision<out V, S : State<S>, E : Effect> {
+  data class Accept<V, S : State<S>, E : Effect>(val value: V, ...) : Decision<V, S, E>()
+  data class Reject<S : State<S>, E : Effect>(val reason: String) : Decision<Nothing, S, E>()
+}
+
+// when expressions for exhaustive matching
+when (val decision = transition.decide(value)) {
+  is Decision.Accept -> { ... }
+  is Decision.Reject -> Result.failure(RejectedTransition(decision.reason))
+}
+```
+
+### ❌ Don't
+
+```kotlin
+// No imperative loops when functional transforms work
+val results = mutableListOf<String>()
+for (state in stateSet) {
+  for (to in state.subsequentStates) {
+    results.add("${state::class.simpleName} --> ${to::class.simpleName}")
+  }
+}
+
+// No var when val works
+var isTerminal = false
+if (subsequentStates.isEmpty()) isTerminal = true
+```
+
+## Testing
+
+Kotest StringSpec with `IsolationMode.InstancePerTest`. Tests live in `lib/src/test/kotlin/app/cash/kfsm/v2/`.
+
+The `exemplar/` package contains a complete reference state machine (`DocumentUpload`) used by tests — update it when adding new library features.
+
+The `testing/` package contains in-memory test doubles (`InMemoryOutbox`, `InMemoryPendingRequestStore`).
+
+### ✅ Do
+
+```kotlin
+class SomeFeatureTest : StringSpec({
+  isolationMode = IsolationMode.InstancePerTest
+
+  // In-memory repository — no mocking
+  val repository = object : Repository<String, DocumentUpload, DocumentState, DocumentEffect> {
+    override fun saveWithOutbox(
+      value: DocumentUpload,
+      outboxMessages: List<OutboxMessage<String, DocumentEffect>>
+    ): Result<DocumentUpload> = Result.success(value)
+  }
+
+  "descriptive test name in lowercase" {
+    val doc = DocumentUpload(id = "doc-1", state = DocumentState.Idle)
+    val result = StateMachine(repository).transition(doc, RequestUpload("test.pdf", byteArrayOf()))
+
+    result.shouldBeSuccess()
+    result.getOrThrow().state shouldBe DocumentState.Uploading
+  }
+})
+```
+
+### ❌ Don't
+
+```kotlin
+// No mocking
+val mockRepo = mockk<Repository<...>>()
+
+// No JUnit assertions
+assertEquals(expected, actual)
+assertTrue(result.isSuccess)
+
+// No AAA comments
+// Arrange ... // Act ... // Assert ...
+```
+
+## Public API
+
+The library uses the [Kotlin Binary Compatibility Validator](https://github.com/Kotlin/binary-compatibility-validator). Changing public API signatures will fail the build — run `bin/gradle apiDump` to update the API dump after intentional changes.

--- a/lib/src/main/kotlin/app/cash/kfsm/v2/State.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/v2/State.kt
@@ -57,6 +57,11 @@ abstract class State<S : State<S>> {
   val subsequentStates: Set<S> by lazy { transitions() }
 
   /**
+   * Whether this state is a terminal (final) state with no outgoing transitions.
+   */
+  val isTerminal: Boolean get() = subsequentStates.isEmpty()
+
+  /**
    * The set of all states that can eventually be reached from this state through any number of transitions.
    */
   val reachableStates: Set<S> by lazy { computeReachableStates() }

--- a/lib/src/main/kotlin/app/cash/kfsm/v2/StateMachineUtilities.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/v2/StateMachineUtilities.kt
@@ -55,13 +55,19 @@ object StateMachineUtilities {
    */
   fun <S : State<S>> mermaid(head: S): Result<String> =
     walkTree(head).map { states ->
+      val allStates = states.toSet()
       listOf("stateDiagram-v2", "[*] --> ${head::class.simpleName}")
         .plus(
-          states
-            .toSet()
+          allStates
             .flatMap { from ->
               from.subsequentStates.map { to -> "${from::class.simpleName} --> ${to::class.simpleName}" }
             }.toList()
+            .sorted()
+        )
+        .plus(
+          allStates
+            .filter { it.isTerminal }
+            .map { "${it::class.simpleName} --> [*]" }
             .sorted()
         ).joinToString("\n")
     }

--- a/lib/src/test/kotlin/app/cash/kfsm/v2/exemplar/DocumentUploadTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/v2/exemplar/DocumentUploadTest.kt
@@ -221,6 +221,13 @@ class DocumentUploadTest : StringSpec({
     notifiedStatus shouldBe "Upload complete"
   }
 
+  "isTerminal is true for states with no subsequent states" {
+    DocumentState.Idle.isTerminal shouldBe false
+    DocumentState.Uploading.isTerminal shouldBe false
+    DocumentState.Scanning.isTerminal shouldBe false
+    DocumentState.Accepted.isTerminal shouldBe true
+  }
+
   "state machine utilities: mermaid diagram shows static transitions" {
     StateMachineUtilities.mermaid(DocumentState.Idle).shouldBeSuccess(
       """
@@ -229,6 +236,7 @@ class DocumentUploadTest : StringSpec({
       Idle --> Uploading
       Scanning --> Accepted
       Uploading --> Scanning
+      Accepted --> [*]
       """.trimIndent()
     )
   }


### PR DESCRIPTION
Add explicit terminal state classification and enhanced diagram generation (#151)

- Add isTerminal property to `State<S>` for identifying terminal states
- Update `StateMachineUtilities.mermaid()` to render terminal state arrows (`State --> [*]`)
- Add tests for isTerminal and updated mermaid diagram expectations